### PR TITLE
Add loading spinner and refine login layout

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -59,9 +59,37 @@ function doGet(e) {
   }
 
 
-  // Padrão: renderiza o formulário
-  return HtmlService.createHtmlOutputFromFile("formulario")
-    .setTitle("Contagem de Estoque - Bar 80");
+  // Padrão: renderiza login ou formulário
+  if (e && e.parameter && e.parameter.page === 'formulario') {
+    return HtmlService.createHtmlOutputFromFile('formulario')
+      .setTitle('Contagem de Estoque - Bar 80');
+  }
+  return HtmlService.createHtmlOutputFromFile('login')
+    .setTitle('Login - Bar 80');
+}
+
+/* =========================
+   LOGIN
+   ========================= */
+function verificarLogin(usuario, senha){
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sh = ss.getSheetByName("Parâmetros") || ss.getSheetByName("Parametros");
+  if(!sh) return {success:false};
+  const last = sh.getLastRow();
+  if(last < 3) return {success:false};
+  const data = sh.getRange(3, 27, last-2, 3).getValues(); // AA,AB,AC
+  const hash = Utilities.base64Encode(Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, senha));
+  for(const row of data){
+    const user = (row[0] || "").toString().trim();
+    const pass = (row[1] || "").toString().trim();
+    const nome = (row[2] || "").toString().trim();
+    if(user && user === usuario){
+      if(pass === senha || pass === hash){
+        return {success:true, nome:nome || user};
+      }
+    }
+  }
+  return {success:false};
 }
 
 

--- a/formulario.html
+++ b/formulario.html
@@ -55,10 +55,26 @@
       footer{background:#1a1a1a;border-top:1px solid #333}
       .dot{background:#555}
       .dot.active{background:linear-gradient(135deg,#1eb0e6,#3d4076)}
+      #loading p{color:#aaa}
+      .spinner{border:1.5vw solid #333;border-top-color:#1eb0e6;border-right-color:#3d4076;border-bottom-color:#f39847;border-left-color:#ef7f5e}
     }
 
     /* tela de "carregando" simples */
-    #loading{display:flex;align-items:center;justify-content:center;height:40vh;color:#555;font-size:4.6vw}
+    #loading{display:flex;flex-direction:column;align-items:center;justify-content:center;height:40vh}
+    .spinner{width:14vw;height:14vw;border-radius:50%;border:1.5vw solid #ddd;border-top-color:#1eb0e6;border-right-color:#3d4076;border-bottom-color:#f39847;border-left-color:#ef7f5e;animation:spin 1s linear infinite}
+    #loading p{margin-top:4vw;font-size:4.6vw;color:#555}
+    @keyframes spin{to{transform:rotate(360deg)}}
+
+    /* modal genérico */
+    .modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;z-index:999}
+    .modal-content{background:#fff;padding:6vw;border-radius:2vw;text-align:center}
+    .modal-content button{margin:2vw;padding:2.5vw 5vw;font-size:4.5vw;border:none;border-radius:2vw;color:#fff;cursor:pointer}
+    .modal-content .confirm{background:#e94373}
+    .modal-content .cancel{background:#bbb;color:#333}
+    @media (prefers-color-scheme: dark){
+      .modal-content{background:#1e1e1e;color:#eee}
+      .modal-content .cancel{background:#444;color:#eee}
+    }
   </style>
 </head>
 <body>
@@ -68,7 +84,7 @@
   </header>
 
   <!-- Loading simples até montar as páginas -->
-  <div id="loading">Carregando formulário…</div>
+  <div id="loading"><div class="spinner"></div><p>Carregando formulário…</p></div>
 
   <div id="appWrap">
     <div id="carrossel"></div>
@@ -111,6 +127,10 @@
     let pages = [];         // apenas os locais
     let current = 0;        // índice dentro de seq
     let ready = false;
+    const responsavel = localStorage.getItem('responsavel');
+    if(!responsavel){
+      window.location.search = '';
+    }
 
     const $loading = document.getElementById('loading');
     const $wrap    = document.getElementById('appWrap');
@@ -222,15 +242,36 @@
         const respostas = Array.from(document.querySelectorAll("select.resposta")).map(s=> s.value==="" ? "0" : s.value);
         const observacoes = document.getElementById("observacoes").value.trim();
         try {
-          google.script.run.salvarRespostas({responsavel:"—", respostas, observacoes});
+          google.script.run.salvarRespostas({responsavel: responsavel || "—", respostas, observacoes});
         } catch(e) {
           console.warn("google.script.run não disponível no preview.", e);
         }
       }
     };
 
-    // Sair: sem função por enquanto
-    $exit.onclick = () => { /* intencionalmente vazio */ };
+    // Sair: mostra confirmação e limpa login
+    $exit.onclick = sair;
+
+    function sair(){
+      const modal = document.createElement('div');
+      modal.className = 'modal';
+      modal.innerHTML = `
+        <div class="modal-content">
+          <p style="font-size:4.5vw;margin-bottom:4vw;">Deseja sair?</p>
+          <button class="confirm" id="sairSim">Sim</button>
+          <button class="cancel" id="sairNao">Não</button>
+        </div>`;
+      document.body.appendChild(modal);
+      modal.style.display = 'flex';
+      document.getElementById('sairSim').onclick = () => {
+        localStorage.clear();
+        window.location.search = '';
+      };
+      document.getElementById('sairNao').onclick = () => {
+        modal.remove();
+      };
+      modal.onclick = (e)=>{ if(e.target===modal) modal.remove(); };
+    }
 
     function reiniciar(){
       document.querySelectorAll("select.resposta").forEach(s=> s.value="");

--- a/login.html
+++ b/login.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <base target="_top">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body{font-family:'Montserrat',Arial,sans-serif;margin:0;display:flex;align-items:center;justify-content:center;height:100vh;background:#f8f9fa;color:#333}
+    .card{background:#fff;padding:6vw;border-radius:3vw;box-shadow:0 1vw 3vw rgba(0,0,0,.2);width:95%;max-width:600px;text-align:center}
+    .card img{max-width:35%;margin:0 auto 3vw}
+    .card h1{font-size:4.8vw;margin-bottom:5vw}
+    .field{margin-bottom:4vw;text-align:left}
+    .field label{display:block;font-weight:600;font-size:4.3vw;margin-bottom:1vw}
+    .field input{width:100%;padding:2.5vw 10vw 2.5vw 2.5vw;font-size:4.3vw;border:0.5vw solid #f39847;border-radius:2vw;background:#fff;color:#000;box-sizing:border-box}
+    .pass-wrapper{position:relative}
+    .show-pass{position:absolute;right:3vw;top:50%;transform:translateY(-50%);font-size:3.5vw;color:#3d4076;cursor:pointer}
+    #loginBtn{width:100%;background:linear-gradient(135deg,#1eb0e6,#3d4076);color:#fff;font-weight:700;padding:3vw;font-size:4.5vw;border:none;border-radius:2vw;cursor:pointer}
+    .info{font-size:3.5vw;margin-top:2vw;color:#555}
+    @media (prefers-color-scheme: dark){
+      body{background:#121212;color:#eee}
+      .card{background:#1e1e1e;color:#eee}
+      .field input{background:#2a2a2a;color:#eee;border-color:#e94373}
+      .info{color:#aaa}
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <img src="https://i.imgur.com/QXV9q62.png" alt="Logo Bar 80">
+    <h1>Sistema de Contagem</h1>
+    <div class="field">
+      <label for="usuario">Usuário:</label>
+      <input type="text" id="usuario" placeholder="Digite seu usuário">
+    </div>
+    <div class="field pass-wrapper">
+      <label for="senha">Senha:</label>
+      <input type="password" id="senha" placeholder="Digite sua senha">
+      <span class="show-pass" id="togglePass">Mostrar</span>
+    </div>
+    <div class="info">Esqueceu a Senha? Solicite alteração para um gestor.</div>
+    <div class="info">Durante a contagem, seus dados ficam salvos mesmo que você saia da página</div>
+    <button id="loginBtn">Entrar</button>
+  </div>
+  <script>
+    document.getElementById('togglePass').onclick = function(){
+      const pass = document.getElementById('senha');
+      if(pass.type === 'password'){ pass.type='text'; this.textContent='Ocultar'; }
+      else { pass.type='password'; this.textContent='Mostrar'; }
+    };
+    document.getElementById('loginBtn').onclick = function(){
+      const usuario = document.getElementById('usuario').value.trim();
+      const senha = document.getElementById('senha').value;
+      if(!usuario || !senha){
+        alert('Preencha usuário e senha.');
+        return;
+      }
+      try{
+        google.script.run.withSuccessHandler(res=>{
+          if(res && res.success){
+            localStorage.setItem('responsavel', res.nome);
+            window.top.location.href='?page=formulario';
+          } else {
+            alert('Usuário ou senha inválidos.');
+          }
+        }).verificarLogin(usuario, senha);
+      }catch(e){
+        console.warn('google.script.run não disponível.', e);
+      }
+    };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Widen login card, align password toggle, and add data persistence note while removing contact link
- Fix login redirection to form and show institutional-color spinner until form structure loads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b57038b608832193c4c6be31b49e89